### PR TITLE
Fix confirmation dialog bug so it renders markdown content instead of plain text content

### DIFF
--- a/src/bits/confirmation-dialog.js
+++ b/src/bits/confirmation-dialog.js
@@ -127,7 +127,7 @@ class ConfirmationDialog extends Bit {
 
   build() {
     const augmentedProps = {
-      text: BuilderHelper.getPlainTextObject(this.props.text),
+      text: BuilderHelper.getMarkdownObject(this.props.text),
       title: BuilderHelper.getPlainTextObject(this.props.title),
       confirm: BuilderHelper.getPlainTextObject(this.props.confirm),
       deny: BuilderHelper.getPlainTextObject(this.props.deny),

--- a/tests/bits/confirmation-dialog.spec.js
+++ b/tests/bits/confirmation-dialog.spec.js
@@ -6,7 +6,7 @@ const helper = require('../helper');
 const className = 'ConfirmationDialog';
 const group = 'Bits';
 
-const config = { className, Class, Dto, classProps, group };
+const config = { className, Class, Dto, classProps, group, expectMarkdown: true };
 
 const properties = [
   props.title,


### PR DESCRIPTION
Fixes #25 

Allow confirmation dialogs to render markdown content instead of just plain text content as per what Slack supports.