### PR TITLE
Typescript: Add typing for Message.printPreviewUrl()

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -425,6 +425,11 @@ declare module 'slack-block-builder' {
         inChannel(): this;
         postAt(timestamp: string): this;
         getAttachments(): Bit.Attachment[];
+        /**
+         * When called, builds the view and prints to the console the preview URL in
+         * order to open and preview the view on the Slack Block Builder website
+         */
+        printPreviewUrl: () => void;
       }
 
       interface ModalParams {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -429,7 +429,7 @@ declare module 'slack-block-builder' {
          * When called, builds the view and prints to the console the preview URL in
          * order to open and preview the view on the Slack Block Builder website
          */
-        printPreviewUrl: () => void;
+        printPreviewUrl(): void;
       }
 
       interface ModalParams {


### PR DESCRIPTION
Wanted to call this, and found it missing. 😄 Addresses #35.