### PR TITLE
:sparkles: Added support for the fallback property on the Bits.Attachment object

### DIFF
--- a/src/bits/attachment.js
+++ b/src/bits/attachment.js
@@ -8,6 +8,7 @@ class AttachmentDto extends SlackDto {
     super();
 
     this.color = params.color;
+    this.fallback = params.fallback;
     this.blocks = params.blocks;
 
     this.pruneAndFreeze();
@@ -19,6 +20,7 @@ class Attachment extends Bit {
     super();
 
     this.props.color = params.color;
+    this.props.fallback = params.fallback;
 
     this.finalizeConstruction();
   }
@@ -34,6 +36,18 @@ class Attachment extends Bit {
 
   color(string) {
     return this.set(string, props.color);
+  }
+
+  /**
+   * Sets the plain text summary of the attachment used in clients that don't show formatted text (eg. IRC, mobile notifications).
+   * 
+   * {@link https://api.slack.com/reference/messaging/attachments|View in Slack API Documentation}
+   * 
+   * @param {string} string
+   * @return {this} The instance on which the method is called
+   */
+  fallback(string) {
+    return this.set(string, props.fallback);
   }
 
   /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,10 +10,12 @@ declare module 'slack-block-builder' {
 
       interface AttachmentParams {
         color?: string;
+        fallback?: string;
       }
 
       interface Attachment extends Bit {
         color(color: string): this;
+        fallback(fallback: string): this;
         blocks(...blocks: Array<Block.Block | Block.Block[]>): this;
       }
 

--- a/src/utility/constants/param-map.js
+++ b/src/utility/constants/param-map.js
@@ -59,6 +59,7 @@ module.exports = {
   responseType: 'response_type',
   postAt: 'post_at',
   color: 'color',
+  fallback: 'fallback',
   attachments: 'attachments',
   dispatchAction: 'dispatch_action',
   dispatchActionConfig: 'dispatch_action_config',

--- a/src/utility/constants/props.js
+++ b/src/utility/constants/props.js
@@ -63,6 +63,7 @@ module.exports = {
   inChannel: 'inChannel',
   ts: 'ts',
   color: 'color',
+  fallback: 'fallback',
   attachments: 'attachments',
   dispatchAction: 'dispatchAction',
   dispatchActionConfig: 'dispatchActionConfig',

--- a/src/utility/validators/default-type-rules.js
+++ b/src/utility/validators/default-type-rules.js
@@ -63,6 +63,7 @@ module.exports = {
   responseType: types.isResponseTypeEnum,
   postAt: types.isTimestamp,
   color: types.isString,
+  fallback: types.isString,
   attachments: types.areAttachments,
   dispatchAction: types.isBool,
   onEnterPressed: types.isDispatchConfigEnum,

--- a/tests/bits/attachment.spec.js
+++ b/tests/bits/attachment.spec.js
@@ -10,6 +10,7 @@ const config = { className, Class, Dto, classProps, group };
 
 const properties = [
   props.color,
+  props.fallback,
   props.blocks,
 ];
 

--- a/tests/bits/mocks/attachment.mock.js
+++ b/tests/bits/mocks/attachment.mock.js
@@ -2,6 +2,7 @@ const { getBits, ...Bits } = require('../../../src/bits');
 
 const props = {
   color: 'color',
+  fallback: 'fallback',
 };
 
 const mock = new Bits.Attachment({ ...props });

--- a/tests/mocks/invalid-prop-data-mapping.js
+++ b/tests/mocks/invalid-prop-data-mapping.js
@@ -64,6 +64,7 @@ module.exports = {
   ephemeral: types.globallyInvalid,
   inChannel: types.globallyInvalid,
   color: types.globallyInvalid,
+  fallback: types.globallyInvalid,
   attachments: types.globallyInvalid,
   dispatchAction: types.globallyInvalid,
   onEnterPressed: types.globallyInvalid,

--- a/tests/mocks/valid-prop-data-mapping.js
+++ b/tests/mocks/valid-prop-data-mapping.js
@@ -64,6 +64,7 @@ module.exports = {
   ephemeral: types.ephemeral,
   inChannel: types.inChannel,
   color: types.string,
+  fallback: types.string,
   attachments: types.arrayAttachments,
   dispatchAction: types.bool,
   onEnterPressed: types.string,

--- a/tests/props/fallback.js
+++ b/tests/props/fallback.js
@@ -1,0 +1,21 @@
+const { props, paramMap } = require('../../src/utility/constants');
+const valid = require('../mocks/valid-prop-data-mapping');
+const invalid = require('../mocks/invalid-prop-data-mapping');
+const checks = require('../checks');
+
+module.exports = (params) => {
+  const config = {
+    ...params,
+    valid: valid.fallback,
+    invalid: invalid.fallback,
+    method: props.fallback,
+    property: props.fallback,
+    param: paramMap.fallback,
+  };
+
+  return [
+    checks.settableProperty(config),
+    checks.invalidValue(config),
+    checks.literalBuild(config),
+  ];
+};

--- a/tests/props/index.js
+++ b/tests/props/index.js
@@ -24,6 +24,7 @@ const ephemeral = require('./ephemeral');
 const excludeBotUsers = require('./exclude-bot-users');
 const excludeExternalSharedChannels = require('./exclude-external-shared-channels');
 const externalId = require('./external-id');
+const fallback = require('./fallback');
 const fields = require('./fields');
 const filter = require('./filter');
 const hint = require('./hint');
@@ -94,6 +95,7 @@ module.exports = {
   excludeBotUsers,
   excludeExternalSharedChannels,
   externalId,
+  fallback,
   fields,
   filter,
   hint,


### PR DESCRIPTION
Fixes #36 

Added support for the fallback property on the Bits.Attachment object, one of the legacy fields.

https://api.slack.com/reference/messaging/attachments#legacy_fields

