### PR TITLE
🏷️ Improve typing of the Context.elements method

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -77,8 +77,10 @@ declare module 'slack-block-builder' {
         blockId?: string;
       }
 
+      type ContextElement = Element.Img | string;
+
       interface Context extends Block {
-        elements(...elements: Array<Element.Element | Element.Element[]>): this;
+        elements(...elements: Array<ContextElement | ContextElement[]>): this;
       }
 
       interface DividerParams {


### PR DESCRIPTION
* Add typing to permit string and string[] arguments, which are used to
  represent markdown text in Block Builder's API.
* Narrow the existing typing from Element -> Img, because contexts can
  only contain text and images.

Fixes #38