### PR TITLE
add emoji to markdown helpers

### DIFF
--- a/src/md/index.ts
+++ b/src/md/index.ts
@@ -93,6 +93,14 @@ export function mailto(email: string, alias: string): string {
 }
 
 /**
+ * @description Converts a named emoji to colon format.
+ */
+
+export function emoji(name: string): string {
+  return `:${name}:`
+}
+
+/**
  * @description Mentions a user in a channel.
  */
 
@@ -128,6 +136,7 @@ const md = {
   listBullet,
   link,
   mailto,
+  emoji,
   user,
   channel,
   group,


### PR DESCRIPTION
Slack docs [Formatting text for app surfaces: Emoji](https://api.slack.com/reference/surfaces/formatting#emoji)
> The list of emoji supported are taken from https://github.com/iamcal/emoji-data