### PR TITLE
:hammer: Refactor printPreviewUrl to use getPreviewUrl

### DIFF
--- a/src/methods/other-methods.ts
+++ b/src/methods/other-methods.ts
@@ -64,9 +64,9 @@ export abstract class GetBlocks extends Builder {
   }
 }
 
-export abstract class PrintPreviewUrl extends Builder {
+export abstract class GetPreviewUrl extends Builder {
   /**
-   * @description When called, builds the view and returns the preview URL in order to open and preview the view on Slack's Block Kit Builder web application.
+   * @description Builds the view and returns the preview URL in order to open and preview the view on Slack's Block Kit Builder web application.
    */
 
   public getPreviewUrl(): string {
@@ -79,9 +79,11 @@ export abstract class PrintPreviewUrl extends Builder {
 
     return encodeURI(`${baseUri}${stringifiedBlocks}`).replace(/[!'()*]/g, escape);
   }
+}
 
+export abstract class PrintPreviewUrl extends GetPreviewUrl {
   /**
-   * @description When called, calls getPreviewUrl to build the preview URL and log it to the console.
+   * @description Calls getPreviewUrl to build the preview URL and log it to the console.
    */
 
   public printPreviewUrl(): void {

--- a/src/methods/other-methods.ts
+++ b/src/methods/other-methods.ts
@@ -66,10 +66,10 @@ export abstract class GetBlocks extends Builder {
 
 export abstract class PrintPreviewUrl extends Builder {
   /**
-   * @description When called, builds the view and prints to the console the preview URL in order to open and preview the view on Slack's Block Kit Builder web application.
+   * @description When called, builds the view and returns the preview URL in order to open and preview the view on Slack's Block Kit Builder web application.
    */
 
-  public printPreviewUrl(): void {
+  public getPreviewUrl(): string {
     const result = this.build();
 
     const baseUri = 'https://app.slack.com/block-kit-builder/#';
@@ -77,7 +77,15 @@ export abstract class PrintPreviewUrl extends Builder {
       ? JSON.stringify(result)
       : JSON.stringify({ blocks: result.blocks, attachments: result.attachments });
 
+    return encodeURI(`${baseUri}${stringifiedBlocks}`).replace(/[!'()*]/g, escape);
+  }
+
+  /**
+   * @description When called, calls getPreviewUrl to build the preview URL and log it to the console.
+   */
+  
+  public printPreviewUrl(): void {
     // eslint-disable-next-line no-console
-    console.log(encodeURI(`${baseUri}${stringifiedBlocks}`).replace(/[!'()*]/g, escape));
+    console.log(this.getPreviewUrl());
   }
 }

--- a/src/methods/other-methods.ts
+++ b/src/methods/other-methods.ts
@@ -83,7 +83,7 @@ export abstract class PrintPreviewUrl extends Builder {
   /**
    * @description When called, calls getPreviewUrl to build the preview URL and log it to the console.
    */
-  
+
   public printPreviewUrl(): void {
     // eslint-disable-next-line no-console
     console.log(this.getPreviewUrl());

--- a/src/surfaces/home-tab.ts
+++ b/src/surfaces/home-tab.ts
@@ -8,6 +8,7 @@ import {
   BuildToJSON,
   BuildToObject,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl,
 } from '../methods';
 import { applyMixins, getBuilderResults } from '../helpers';
@@ -29,6 +30,7 @@ export interface HomeTabBuilder extends Blocks<ViewBlockBuilder>,
   BuildToJSON,
   BuildToObject<SlackViewDto>,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl {
 }
 
@@ -56,5 +58,6 @@ applyMixins(HomeTabBuilder, [
   BuildToJSON,
   BuildToObject,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl,
 ]);

--- a/src/surfaces/message.ts
+++ b/src/surfaces/message.ts
@@ -18,6 +18,7 @@ import {
   BuildToObject,
   GetAttachments,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl,
 } from '../methods';
 import { applyMixins, getBuilderResults } from '../helpers';
@@ -50,6 +51,7 @@ export interface MessageBuilder extends AsUser,
   BuildToObject<SlackMessageDto>,
   GetAttachments,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl {
 }
 
@@ -87,5 +89,6 @@ applyMixins(MessageBuilder, [
   BuildToObject,
   GetAttachments,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl,
 ]);

--- a/src/surfaces/modal.ts
+++ b/src/surfaces/modal.ts
@@ -13,6 +13,7 @@ import {
   BuildToJSON,
   BuildToObject,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl,
 } from '../methods';
 import { applyMixins, getPlainTextObject, getBuilderResults } from '../helpers';
@@ -43,6 +44,7 @@ export interface ModalBuilder extends Blocks<ViewBlockBuilder>,
   BuildToJSON,
   BuildToObject<SlackViewDto>,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl {
 }
 
@@ -78,5 +80,6 @@ applyMixins(ModalBuilder, [
   BuildToJSON,
   BuildToObject,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl,
 ]);

--- a/src/surfaces/workflow-step.ts
+++ b/src/surfaces/workflow-step.ts
@@ -8,6 +8,7 @@ import {
   BuildToJSON,
   BuildToObject,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl,
 } from '../methods';
 import { applyMixins, getPlainTextObject, getBuilderResults } from '../helpers';
@@ -28,6 +29,7 @@ export interface WorkflowStepBuilder extends Blocks<ViewBlockBuilder>,
   BuildToJSON,
   BuildToObject<SlackViewDto>,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl {
 }
 
@@ -58,5 +60,6 @@ applyMixins(WorkflowStepBuilder, [
   BuildToJSON,
   BuildToObject,
   GetBlocks,
+  GetPreviewUrl,
   PrintPreviewUrl,
 ]);

--- a/tests/surfaces/surface.spec.ts
+++ b/tests/surfaces/surface.spec.ts
@@ -25,6 +25,24 @@ describe('Surfaces', () => {
     expect(result).toEqual(JSON.stringify(modal.build()));
   });
 
+  test('Calling \'getPreviewUrl()\' for HomeTab returns the URL as a string.', () => {
+    const modal = HomeTab()
+      .blocks(Blocks.Divider());
+
+    const result = modal.getPreviewUrl();
+
+    expect(result).toEqual('https://app.slack.com/block-kit-builder/#%7B%22blocks%22:%5B%7B%22type%22:%22divider%22%7D%5D%7D');
+  });
+
+  test('Calling \'getPreviewUrl()\' for Modal returns the URL as a string.', () => {
+    const message = Modal()
+      .blocks(Blocks.Divider());
+
+    const result = message.getPreviewUrl();
+
+    expect(result).toEqual('https://app.slack.com/block-kit-builder/#%7B%22blocks%22:%5B%7B%22type%22:%22divider%22%7D%5D%7D');
+  });
+
   test('Calling \'printPreviewUrl()\' for HomeTab logs the URL to the console.', () => {
     const modal = HomeTab()
       .blocks(Blocks.Divider());


### PR DESCRIPTION
I've run into a case where I want the preview URL but don't want to log it to the console.

I've separated this into two separate functions so now when you do printPreviewUrl, it calls getPreviewUrl and everything works just as before, but you can also just call getPreviewUrl to get the string and do with it what you please.

This came up for me because I wanted the URL to be on a page.

Have no added it to the documentation though.