### PR TITLE
:bug: Fix preview url for home and modal surfaces

### DIFF
--- a/src/methods/other-methods.ts
+++ b/src/methods/other-methods.ts
@@ -73,7 +73,7 @@ export abstract class GetPreviewUrl extends Builder {
     const result = this.build();
 
     const baseUri = 'https://app.slack.com/block-kit-builder/#';
-    const stringifiedBlocks = this.props.type
+    const stringifiedBlocks = result.type
       ? JSON.stringify(result)
       : JSON.stringify({ blocks: result.blocks, attachments: result.attachments });
 

--- a/tests/surfaces/surface.spec.ts
+++ b/tests/surfaces/surface.spec.ts
@@ -31,16 +31,16 @@ describe('Surfaces', () => {
 
     const result = modal.getPreviewUrl();
 
-    expect(result).toEqual('https://app.slack.com/block-kit-builder/#%7B%22blocks%22:%5B%7B%22type%22:%22divider%22%7D%5D%7D');
+    expect(result).toEqual('https://app.slack.com/block-kit-builder/#%7B%22blocks%22:%5B%7B%22type%22:%22divider%22%7D%5D,%22type%22:%22home%22%7D');
   });
 
   test('Calling \'getPreviewUrl()\' for Modal returns the URL as a string.', () => {
-    const message = Modal()
+    const message = Modal({ submit: 'Start' })
       .blocks(Blocks.Divider());
 
     const result = message.getPreviewUrl();
 
-    expect(result).toEqual('https://app.slack.com/block-kit-builder/#%7B%22blocks%22:%5B%7B%22type%22:%22divider%22%7D%5D%7D');
+    expect(result).toEqual('https://app.slack.com/block-kit-builder/#%7B%22submit%22:%7B%22type%22:%22plain_text%22,%22text%22:%22Start%22%7D,%22blocks%22:%5B%7B%22type%22:%22divider%22%7D%5D,%22type%22:%22modal%22%7D');
   });
 
   test('Calling \'printPreviewUrl()\' for HomeTab logs the URL to the console.', () => {


### PR DESCRIPTION
While trying out your package I found that "meta" information on the modal, like submit and cancel text were lost, while they were available in the built JSON.

This fixes it and also makes the Block Kit Builder open it in the right preview format 🎉 