### PR TITLE
Copy builder constructor properties.  Fixes #102

### DIFF
--- a/src/internal/lib/builder.ts
+++ b/src/internal/lib/builder.ts
@@ -6,7 +6,7 @@ export abstract class Builder {
   protected readonly props: ObjectLiteral;
 
   constructor(params?: ObjectLiteral) {
-    this.props = params || {};
+    this.props = params && {...params} || {};
 
     Object.keys(this.props)
       .forEach((prop) => this.props[prop] === undefined

--- a/src/internal/lib/builder.ts
+++ b/src/internal/lib/builder.ts
@@ -6,7 +6,7 @@ export abstract class Builder {
   protected readonly props: ObjectLiteral;
 
   constructor(params?: ObjectLiteral) {
-    this.props = params && {...params} || {};
+    this.props = params ? { ...params } : {};
 
     Object.keys(this.props)
       .forEach((prop) => this.props[prop] === undefined

--- a/tests/lib/builder.spec.ts
+++ b/tests/lib/builder.spec.ts
@@ -20,4 +20,21 @@ describe('Testing Builder Class Methods:', () => {
 
     expect(() => fakeBuilder.build()).toThrow();
   });
+
+  test('Builder constructor should copy properties.', () => {
+    class TestBuilder extends Builder {
+      public set(value: unknown, prop: string): this {
+        return super.set(value, prop);
+      }
+    }
+
+    const commonProps = {foo: '42'};
+    const testBuilder1 = new TestBuilder(commonProps);
+    const testBuilder2 = new TestBuilder(commonProps);
+
+    expect(() => testBuilder1.set('43', 'foo')).toThrow(); // property already set via constructor
+
+    testBuilder1.set('value', 'prop');
+    expect(() => testBuilder2.set('value', 'prop')).not.toThrow(); // each builder instance has its own properties
+  });
 });

--- a/tests/lib/builder.spec.ts
+++ b/tests/lib/builder.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import { Modal } from '../../src';
 import { Builder } from '../../src/internal';
 
@@ -28,7 +29,7 @@ describe('Testing Builder Class Methods:', () => {
       }
     }
 
-    const commonProps = {foo: '42'};
+    const commonProps = { foo: '42' };
     const testBuilder1 = new TestBuilder(commonProps);
     const testBuilder2 = new TestBuilder(commonProps);
 


### PR DESCRIPTION
Builder instances should copy the constructor properties argument instead of assigning it directly.  This prevents an error if multiple instances later set the same property.