### PR TITLE
Added text attributes object to customize text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 package-lock.json
 dist/
 docs-generator-dist/
+.vscode/

--- a/src/blocks/section.ts
+++ b/src/blocks/section.ts
@@ -3,9 +3,9 @@ import { BlockType } from '../internal/constants';
 import { SlackBlockDto } from '../internal/dto';
 import {
   applyMixins,
-  getMarkdownObject,
   getBuilderResult,
   getFields,
+  getTextObject,
 } from '../internal/helpers';
 import {
   Accessory,
@@ -13,21 +13,25 @@ import {
   End,
   Fields,
   Text,
+  TextAttributes,
 } from '../internal/methods';
 
 import type { SlackElementDto } from '../internal/dto';
+import { TextAttributesType } from '../internal/objects/text-attributes-object';
 
 export interface SectionParams {
   blockId?: string;
   text?: string;
+  textAttributes?: TextAttributesType;
 }
 
-export interface SectionBuilder extends Accessory,
+export interface SectionBuilder
+  extends Accessory,
   BlockId,
   End,
   Fields,
-  Text {
-}
+  Text,
+  TextAttributes {}
 
 /**
  * @@link https://api.slack.com/reference/block-kit/blocks#section
@@ -40,7 +44,7 @@ export class SectionBuilder extends BlockBuilderBase {
   public build(): Readonly<SlackBlockDto> {
     return this.getResult(SlackBlockDto, {
       type: BlockType.Section,
-      text: getMarkdownObject(this.props.text),
+      text: getTextObject(this.props.text, this.props.textAttributes),
       fields: getFields(this.props.fields),
       accessory: getBuilderResult<SlackElementDto>(this.props.accessory),
     });
@@ -53,4 +57,5 @@ applyMixins(SectionBuilder, [
   End,
   Fields,
   Text,
+  TextAttributes,
 ]);

--- a/src/internal/constants/props.ts
+++ b/src/internal/constants/props.ts
@@ -87,4 +87,5 @@ export enum Prop {
   TitleUrl = 'titleUrl',
   ThumbnailUrl = 'thumbnailUrl',
   VideoUrl = 'videoUrl',
+  TextAttributes = 'textAttributes',
 }

--- a/src/internal/helpers/build-helpers.ts
+++ b/src/internal/helpers/build-helpers.ts
@@ -7,12 +7,10 @@ import {
   DispatchActionsConfigurationObject,
 } from '../objects';
 
-import type {
-  ObjectLiteral,
-  ContextElement,
-  Undefinable,
-} from '../types';
+import type { ObjectLiteral, ContextElement, Undefinable } from '../types';
 import type { SlackElementDto } from '../dto';
+import { ObjectType } from '../constants';
+import { TextAttributesType } from '../objects/text-attributes-object';
 
 const defaultParams = {
   isMarkdown: false,
@@ -28,39 +26,73 @@ const valuesOrUndefined = <T extends unknown[]>(values: T): Undefinable<T> => {
   return values;
 };
 
-export function getBuilderResult<T>(builder: Builder, params: ObjectLiteral = defaultParams): T {
+export function getBuilderResult<T>(
+  builder: Builder,
+  params: ObjectLiteral = defaultParams,
+): T {
   return valueOrUndefined(builder) && builder.build(params);
 }
 
 export function getBuilderResults<T>(
-  builders: Builder[], params: ObjectLiteral = defaultParams,
+  builders: Builder[],
+  params: ObjectLiteral = defaultParams,
 ): Undefinable<T[]> {
-  return valueOrUndefined(builders) && builders
-    .map((builder) => getBuilderResult<T>(builder, params));
+  return (
+    valueOrUndefined(builders)
+    && builders.map((builder) => getBuilderResult<T>(builder, params))
+  );
 }
 
-export function getPlainTextObject(text: string): Undefinable<PlainTextObject> {
-  return valueOrUndefined(text) ? new PlainTextObject(text) : undefined;
+export function getPlainTextObject(
+  text: string,
+  emoji?: boolean,
+): Undefinable<PlainTextObject> {
+  return valueOrUndefined(text) ? new PlainTextObject(text, emoji) : undefined;
 }
 
 export function getStringFromNumber(value: number): Undefinable<string> {
   return valueOrUndefined(value) ? value.toString() : undefined;
 }
 
-export function getMarkdownObject(text: string): Undefinable<MarkdownObject> {
-  return valueOrUndefined(text) ? new MarkdownObject(text) : undefined;
+export function getMarkdownObject(
+  text: string,
+  verbatim?: boolean,
+): Undefinable<MarkdownObject> {
+  return valueOrUndefined(text)
+    ? new MarkdownObject(text, verbatim)
+    : undefined;
+}
+
+export function getTextObject(
+  text: string,
+  textAttributes: Undefinable<TextAttributesType>,
+): Undefinable<PlainTextObject | MarkdownObject> {
+  if (!textAttributes || (textAttributes.type !== ObjectType.Text
+    && textAttributes.type !== ObjectType.Markdown)) {
+    return getMarkdownObject(text); // Default to markdown
+  }
+  if (textAttributes.type === ObjectType.Text) {
+    return getPlainTextObject(text, textAttributes.emoji);
+  }
+
+  return getMarkdownObject(text, textAttributes.verbatim);
 }
 
 export function getElementsForContext(
   elements: ContextElement[],
 ): Undefinable<Array<MarkdownObject | Readonly<SlackElementDto>>> {
-  return valueOrUndefined(elements) && elements.map((element) => (typeof element === 'string'
-    ? new MarkdownObject(element)
-    : element.build()));
+  return (
+    valueOrUndefined(elements)
+    && elements.map((element) => (typeof element === 'string'
+      ? new MarkdownObject(element)
+      : element.build()))
+  );
 }
 
 export function getFields(fields: string[]): Undefinable<MarkdownObject[]> {
-  return valueOrUndefined(fields) && fields.map((field) => new MarkdownObject(field));
+  return (
+    valueOrUndefined(fields) && fields.map((field) => new MarkdownObject(field))
+  );
 }
 
 export function getFormattedDate(date: Date): Undefinable<string> {
@@ -71,17 +103,29 @@ export function getDateTimeIntegerFromDate(date: Date): Undefinable<number> {
   return valueOrUndefined(date) && Math.floor(date.getTime() / 1000);
 }
 
-export function getFilter(
-  { filter, excludeBotUsers, excludeExternalSharedChannels }: FilterParams,
-): Undefinable<FilterObject> {
-  return valuesOrUndefined([filter, excludeBotUsers, excludeExternalSharedChannels])
-    && new FilterObject({ filter, excludeBotUsers, excludeExternalSharedChannels });
+export function getFilter({
+  filter,
+  excludeBotUsers,
+  excludeExternalSharedChannels,
+}: FilterParams): Undefinable<FilterObject> {
+  return (
+    valuesOrUndefined([
+      filter,
+      excludeBotUsers,
+      excludeExternalSharedChannels,
+    ])
+    && new FilterObject({ filter, excludeBotUsers, excludeExternalSharedChannels })
+  );
 }
 
-export function getDispatchActionsConfigurationObject(
-  { onEnterPressed, onCharacterEntered }: ObjectLiteral,
-): Undefinable<DispatchActionsConfigurationObject> {
-  return valuesOrUndefined([onEnterPressed, onCharacterEntered])
-    && new DispatchActionsConfigurationObject([onEnterPressed, onCharacterEntered]
-      .filter(Boolean));
+export function getDispatchActionsConfigurationObject({
+  onEnterPressed,
+  onCharacterEntered,
+}: ObjectLiteral): Undefinable<DispatchActionsConfigurationObject> {
+  return (
+    valuesOrUndefined([onEnterPressed, onCharacterEntered])
+    && new DispatchActionsConfigurationObject(
+      [onEnterPressed, onCharacterEntered].filter(Boolean),
+    )
+  );
 }

--- a/src/internal/methods/set-methods.ts
+++ b/src/internal/methods/set-methods.ts
@@ -6,6 +6,7 @@ import { Prop } from '../constants';
 
 import type { SectionElementBuilder, Settable } from '../types';
 import type { OptionBuilder } from '../../bits';
+import { TextAttributesType } from '../objects/text-attributes-object';
 
 export abstract class AccessibilityLabel extends Builder {
   /**
@@ -637,6 +638,23 @@ export abstract class Text extends Builder {
 
   public text(text: Settable<string>): this {
     return this.set(text, Prop.Text);
+  }
+}
+export abstract class TextAttributes extends Builder {
+  /**
+   * @description Controls the attributes of a string.
+   *
+   * **Slack Validation Rules and Tips:**
+   *    * Only usable when text type is 'mrkdwn'.
+   *    * When set to false (default) URLs will be auto-converted into links, conversation names will be link-ified, and certain mentions will be automatically parsed.
+   *    * When set to true, any preprocessing will be skipped. However, you can still include manual parsing strings.
+   *
+   * {@link https://api.slack.com/block-kit|Open Official Slack Block Kit Documentation}
+   * {@link https://www.blockbuilder.dev|Open Block Builder Documentation}
+   */
+
+  public textAttributes(textAttributes: Settable<TextAttributesType>): this {
+    return this.set(textAttributes, Prop.TextAttributes);
   }
 }
 

--- a/src/internal/objects/markdown-object.ts
+++ b/src/internal/objects/markdown-object.ts
@@ -6,10 +6,13 @@ export class MarkdownObject extends CompositionObjectBase {
 
   public text: string;
 
-  constructor(text: string) {
+  public verbatim?: boolean;
+
+  constructor(text: string, verbatim?: boolean) {
     super();
 
     this.type = ObjectType.Markdown;
     this.text = text;
+    this.verbatim = verbatim;
   }
 }

--- a/src/internal/objects/plain-text-object.ts
+++ b/src/internal/objects/plain-text-object.ts
@@ -6,10 +6,13 @@ export class PlainTextObject extends CompositionObjectBase {
 
   public text: string;
 
-  constructor(text: string) {
+  public emoji?: boolean;
+
+  constructor(text: string, emoji?: boolean) {
     super();
 
     this.type = ObjectType.Text;
     this.text = text;
+    this.emoji = emoji;
   }
 }

--- a/src/internal/objects/text-attributes-object.ts
+++ b/src/internal/objects/text-attributes-object.ts
@@ -1,0 +1,17 @@
+import { ObjectType } from '../constants/object-types';
+
+export interface TextAttributesBase {
+  type: ObjectType.Markdown | ObjectType.Text;
+}
+
+export interface MarkdownTextAttributes extends TextAttributesBase {
+  type: ObjectType.Markdown;
+  verbatim?: boolean;
+}
+
+export interface PlainTextAttributes extends TextAttributesBase {
+  type: ObjectType.Text;
+  emoji?: boolean;
+}
+
+export type TextAttributesType = PlainTextAttributes | MarkdownTextAttributes;


### PR DESCRIPTION
This PR is related to: https://github.com/raycharius/slack-block-builder/issues/82

This adds support for adding parameters to alter text via the `textAttributes` object. There were problems figuring out how to add tests, so any help on that would be appreciated.