### PR TITLE
add altText to video params

### DIFF
--- a/src/blocks/video.ts
+++ b/src/blocks/video.ts
@@ -17,6 +17,7 @@ import {
 } from '../internal/methods';
 
 export interface VideoParams {
+  altText?: string;
   blockId?: string;
   description?: string;
   providerIconUrl?: string;


### PR DESCRIPTION
currently when using video blocks we either have to do: 

```
Blocks.Video({
     videoUrl: upload.url,
     thumbnailUrl: upload.url,
     //@ts-expect-error
     altText: 'video',
     title: 'video'
})
```
or:

```
Blocks.Video({
     videoUrl: upload.url,
     thumbnailUrl: upload.url,    
     title: 'video'
}).altText('video')
```
but since `altText` is required, would be nice to have it in `VideoParams`. Also would then be consistent with `ImageParams`.