### PR TITLE
Feat: Add type support for multiline plain text inputs

### DIFF
--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -297,6 +297,7 @@ export function StaticSelect(params?: StaticSelectParams): StaticSelectBuilder {
  * @param {string} [params.actionId] Sets a string to be an identifier for the source of an action in interaction payloads.
  * @param {string} [params.placeholder] Adds the text in place of the input before selected or interacted with.
  * @param {string} [params.initialValue] Sets the default text entered into the text input at modal render.
+ * @param {boolean} [params.multiline] Sets wether the input will be a single line or a larger text area.
  * @param {int} [params.minLength] Sets a minimum character count in order for the user to submit the form.
  * @param {int} [params.maxLength] Sets a maximum character count allowed to send the form.
  *
@@ -304,7 +305,8 @@ export function StaticSelect(params?: StaticSelectParams): StaticSelectBuilder {
  */
 
 export function TextInput(params?: TextInputParams): TextInputBuilder {
-  return new TextInputBuilder(params);
+  const input = new TextInputBuilder(params);
+  return input;
 }
 
 /**

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -67,7 +67,7 @@ export type {
   UserMultiSelectBuilder,
   UserMultiSelectParams,
   UserSelectBuilder,
-  UserSelectParams,
+  UserSelectParams
 };
 
 /**
@@ -305,8 +305,7 @@ export function StaticSelect(params?: StaticSelectParams): StaticSelectBuilder {
  */
 
 export function TextInput(params?: TextInputParams): TextInputBuilder {
-  const input = new TextInputBuilder(params);
-  return input;
+  return new TextInputBuilder(params);
 }
 
 /**

--- a/src/elements/text-input.ts
+++ b/src/elements/text-input.ts
@@ -18,6 +18,7 @@ import {
 export interface TextInputParams {
   actionId?: string;
   initialValue?: string;
+  multiline?: boolean;
   maxLength?: number;
   minLength?: number;
   placeholder?: string;


### PR DESCRIPTION
Addressing the issue #121.

Just adding type support for the multiline option on Plan Text Inputs.