### PR TITLE
fix: Update slack-dto.ts

### DIFF
--- a/src/internal/dto/slack-dto.ts
+++ b/src/internal/dto/slack-dto.ts
@@ -112,6 +112,9 @@ export class SlackMessageDto extends SlackDto {
   // @ts-ignore -- Dynamically created class
   public readonly channel: string;
 
+  // @ts-ignore -- Dynamically created class
+  public readonly ts: string;
+
   public readonly blocks?: SlackBlockDto[];
 
   public readonly attachments?: SlackDto[];


### PR DESCRIPTION
fixes this typing error: Argument of type 'Readonly<SlackMessageDto>' is not assignable to parameter of type 'ChatUpdateArguments'.
  Property 'ts' is missing in type 'Readonly<SlackMessageDto>' but required in type 'ChatUpdateArguments'.

when doing

```ts
 await client.chat.update(
      Message()
        //omitted for brevity
        .channel('channel_id')
        .ts('message_ts')
        .buildToObject()
    )
```