### PR TITLE
Add unfurl_links and unfurl_media to Message

### DIFF
--- a/docs/surfaces/message.md
+++ b/docs/surfaces/message.md
@@ -33,6 +33,10 @@ Each instance of the `MessageBuilder` object has chainable setter methods for th
 
 `ts` – *String*
 
+`unfurlLinks` - *Boolean*
+
+`unfurlMedia` - *Boolean*
+
 
 ?> **Note:** For an explanation of any one of the parameters, see its corresponding setter method below.
 

--- a/src/internal/constants/props.ts
+++ b/src/internal/constants/props.ts
@@ -64,6 +64,8 @@ export enum Prop {
   DeleteOriginal = 'deleteOriginal',
   ResponseType = 'responseType',
   PostAt = 'postAt',
+  UnfurlLinks = 'unfurlLinks',
+  UnfurlLinks = 'unfurlMedia',
   Ephemeral = 'ephemeral',
   InChannel = 'inChannel',
   Ts = 'ts',
@@ -89,4 +91,5 @@ export enum Prop {
   VideoUrl = 'videoUrl',
   MaxFiles = 'maxFiles',
   Filetypes = 'filetypes',
+
 }

--- a/src/internal/dto/slack-dto.ts
+++ b/src/internal/dto/slack-dto.ts
@@ -66,6 +66,8 @@ export enum Param {
   deleteOriginal = 'delete_original',
   responseType = 'response_type',
   postAt = 'post_at',
+  unfurlLinks = 'unfurl_links',
+  unfurlMedia = 'unfurl_media',
   color = 'color',
   fallback = 'fallback',
   attachments = 'attachments',

--- a/src/internal/methods/set-methods.ts
+++ b/src/internal/methods/set-methods.ts
@@ -561,6 +561,32 @@ export abstract class PostAt extends Builder {
   }
 }
 
+export abstract class UnfurlLinks extends Builder {
+  /**
+   * @description Enables (or disables) unfurling of primarily text-based content.
+   *
+   * {@link https://api.slack.com/block-kit|Open Official Slack Block Kit Documentation}
+   * {@link https://www.blockbuilder.dev|Open Block Builder Documentation}
+   */
+
+  public unfurlLinks(unfurlLinks: Settable<boolean>): this {
+    return this.set(unfurlLinks, Prop.UnfurlLinks);
+  }
+}
+
+export abstract class UnfurlMedia extends Builder {
+  /**
+   * @description Enables (or disables) unfurling of primarily text-based content.
+   *
+   * {@link https://api.slack.com/block-kit|Open Official Slack Block Kit Documentation}
+   * {@link https://www.blockbuilder.dev|Open Block Builder Documentation}
+   */
+
+  public unfurlMedia(unfurlMedia: Settable<boolean>): this {
+    return this.set(unfurlMedia, Prop.UnfurlLinks);
+  }
+}
+
 export abstract class PrivateMetaData extends Builder {
   /**
    * @description Defines a string sent back to your server with view and interaction payloads.

--- a/src/surfaces/index.ts
+++ b/src/surfaces/index.ts
@@ -39,6 +39,8 @@ export function HomeTab(params?: HomeTabParams): HomeTabBuilder {
  * @param {string} [params.text] Text to be displayed in the notification on the Message, or in the body, if there are no Blocks available.
  * @param {timestamp} [params.threadTs] Sets the message to be a reply in a thread to the message whose timestamp is passed.
  * @param {timestamp} [params.postAt] Sets a time for the message to be posted, as a scheduled message.
+ * @param {boolean} [params.unfurlLinks] Sets whether Slack should unfurl links in the Message.
+ * @param {boolean} [params.unfurlMedia] Sets whether Slack should unfurl media in the Message.
  *
  * {@link https://api.slack.com/messaging/composing|View in Slack API Documentation}
  */

--- a/src/surfaces/message.ts
+++ b/src/surfaces/message.ts
@@ -21,6 +21,8 @@ import {
   GetBlocks,
   GetPreviewUrl,
   PrintPreviewUrl,
+  UnfurlLinks,
+  UnfurlMedia,
 } from '../internal/methods';
 
 import type { SlackBlockDto, SlackDto } from '../internal/dto';
@@ -32,6 +34,8 @@ export interface MessageParams {
   text?: string;
   threadTs?: string;
   ts?: string;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
 }
 
 export interface MessageBuilder extends AsUser,
@@ -47,6 +51,8 @@ export interface MessageBuilder extends AsUser,
   Text,
   ThreadTs,
   Ts,
+  UnfurlLinks,
+  UnfurlMedia,
   BuildToJSON,
   BuildToObject<SlackMessageDto>,
   GetAttachments,
@@ -85,6 +91,8 @@ applyMixins(MessageBuilder, [
   Text,
   ThreadTs,
   Ts,
+  UnfurlLinks,
+  UnfurlMedia,
   BuildToJSON,
   BuildToObject,
   GetAttachments,

--- a/tests/methods/index.ts
+++ b/tests/methods/index.ts
@@ -84,3 +84,5 @@ export * from './value';
 export * from './video-url';
 export * from './max-files';
 export * from './filetypes';
+export * from './unfurl-links';
+export * from './unfurl-media';

--- a/tests/methods/unfurl-links.ts
+++ b/tests/methods/unfurl-links.ts
@@ -1,0 +1,18 @@
+import { CompositeBuilderClassConfig } from '../test-config-types';
+import { Prop } from '../../src/internal/constants';
+import { methodArgMocks } from '../mocks/method-arg-mocks';
+import { SlackDto } from '../../src/internal';
+import * as checks from '../checks';
+
+export const unfurlLinks = (params: CompositeBuilderClassConfig): void => {
+  const config = {
+    ...params,
+    methodArgMock: methodArgMocks.unfurlLinks,
+    methodName: Prop.UnfurlLinks,
+    propSetterPropName: Prop.UnfurlLinks,
+    slackDtoParamName: SlackDto.mapParam(Prop.UnfurlLinks),
+  };
+
+  checks.settableProperty(config);
+  checks.literalBuild(config);
+};

--- a/tests/methods/unfurl-media.ts
+++ b/tests/methods/unfurl-media.ts
@@ -1,0 +1,18 @@
+import { CompositeBuilderClassConfig } from '../test-config-types';
+import { Prop } from '../../src/internal/constants';
+import { methodArgMocks } from '../mocks/method-arg-mocks';
+import { SlackDto } from '../../src/internal';
+import * as checks from '../checks';
+
+export const unfurlMedia = (params: CompositeBuilderClassConfig): void => {
+  const config = {
+    ...params,
+    methodArgMock: methodArgMocks.unfurlMedia,
+    methodName: Prop.UnfurlLinks,
+    propSetterPropName: Prop.UnfurlLinks,
+    slackDtoParamName: SlackDto.mapParam(Prop.UnfurlLinks),
+  };
+
+  checks.settableProperty(config);
+  checks.literalBuild(config);
+};

--- a/tests/mocks/method-arg-mocks.ts
+++ b/tests/mocks/method-arg-mocks.ts
@@ -61,6 +61,8 @@ export const methodArgMocks = {
   asUser: methodArgMocksByType.bool,
   threadTs: methodArgMocksByType.string,
   ts: methodArgMocksByType.string,
+  unfurlLinks: methodArgMocksByType.bool,
+  unfurlMedia: methodArgMocksByType.bool,
   replaceOriginal: methodArgMocksByType.bool,
   deleteOriginal: methodArgMocksByType.bool,
   responseType: methodArgMocksByType.ephemeral,

--- a/tests/surfaces/message.spec.ts
+++ b/tests/surfaces/message.spec.ts
@@ -29,6 +29,8 @@ const methodsConfig = [
   methods.ts,
   methods.attachments,
   methods.ignoreMarkdown,
+  methods.unfurlLinks,
+  methods.unfurlMedia,
 ];
 
 testCompositeBuilderClass({ config, methods: methodsConfig });


### PR DESCRIPTION
Closes #119 

I added it by following where the other values like `threadTs` are used/tested, but I could have missed something. I can't run tests because of some TS issues:

```
src/internal/exception/error.ts:6:11 - error TS2339: Property 'captureStackTrace' does not exist on type 'ErrorConstructor'.
```

Should `@types/node` be added as a dev dependency?

I personally prefer snake_case for the parameters (so `unfurl_links` instead of `unfurlLinks`) but I kept it camelCase for consistency with the other code. 